### PR TITLE
Add a boolean option for better typescript support?

### DIFF
--- a/CommandHandler.ts
+++ b/CommandHandler.ts
@@ -14,17 +14,17 @@ import cooldown from './models/cooldown'
 class CommandHandler {
   private _commands: Map<String, Command> = new Map()
 
-  constructor(instance: WOKCommands, client: Client, dir: string) {
+  constructor(instance: WOKCommands, client: Client, dir: string, useTypeScript?: boolean) {
     // Register built in commands
     for (const [file, fileName] of getAllFiles(
       path.join(__dirname, 'commands')
-    )) {
+    ), useTypeScript) {
       this.registerCommand(instance, client, file, fileName)
     }
 
     if (dir) {
       if (fs.existsSync(dir)) {
-        const files = getAllFiles(dir)
+        const files = getAllFiles(dir, useTypeScript)
 
         const amount = files.length
         if (amount > 0) {

--- a/FeatureHandler.ts
+++ b/FeatureHandler.ts
@@ -16,10 +16,10 @@ const loadFeature = (
 class FeatureHandler {
   private _features: Map<String, String[]> = new Map() // <Feature name, Disabled GuildIDs>
 
-  constructor(client: Client, instance: WOKCommands, dir: string) {
+  constructor(client: Client, instance: WOKCommands, dir: string, useTypeScipt?: boolean) {
     if (dir) {
       if (fs.existsSync(dir)) {
-        const files = getAllFiles(dir)
+        const files = getAllFiles(dir, useTypeScript)
 
         const amount = files.length
         if (amount > 0) {

--- a/get-all-files.ts
+++ b/get-all-files.ts
@@ -1,6 +1,6 @@
 import fs, { Dirent } from 'fs'
 
-const getAllFiles = (dir: string) => {
+const getAllFiles = (dir: string, useTypeScript?: boolean) => {
   const files: Dirent[] = fs.readdirSync(dir, {
     withFileTypes: true,
   })
@@ -9,7 +9,7 @@ const getAllFiles = (dir: string) => {
   for (const file of files) {
     if (file.isDirectory()) {
       jsFiles = [...jsFiles, ...getAllFiles(`${dir}/${file.name}`)]
-    } else if (file.name.endsWith('.js')) {
+    } else if (file.name.endsWith(useTypeScript ? '.ts' : '.js')) {
       let fileName: string | string[] = file.name.replace(/\\/g, '/').split('/')
       fileName = fileName[fileName.length - 1]
       fileName = fileName.split('.')[0].toLowerCase()

--- a/index.ts
+++ b/index.ts
@@ -31,7 +31,8 @@ class WOKCommands extends EventEmitter {
     commandsDir?: string,
     featureDir?: string,
     messagesPath?: string,
-    showWarns?: boolean
+    showWarns?: boolean,
+    useTypeScript?: boolean,
   ) {
     super()
 
@@ -81,9 +82,9 @@ class WOKCommands extends EventEmitter {
     this._commandsDir = commandsDir || this._commandsDir
     this._featureDir = featureDir || this._featureDir
 
-    this._commandHandler = new CommandHandler(this, client, this._commandsDir)
+    this._commandHandler = new CommandHandler(this, client, this._commandsDir, useTypeScript)
     if (this._featureDir) {
-      this._featureHandler = new FeatureHandler(client, this, this._featureDir)
+      this._featureHandler = new FeatureHandler(client, this, this._featureDir, useTypeScript)
     }
 
     this._messageHandler = new MessageHandler(this, messagesPath)


### PR DESCRIPTION
Some people had problems with TypeScript using this lib, so I added a boolean option named `useTypeScript` that simply makes `getAllFiles` get TypeScript files instead.

Since I am a noob at github this PR cannot be automatically be merged, and you should probably go over the changes first. Thanks.