### PR TITLE
cooldown or globalCooldown, not both

### DIFF
--- a/src/interfaces/ICommand.ts
+++ b/src/interfaces/ICommand.ts
@@ -1,4 +1,4 @@
-export default interface ICommand {
+interface BaseCommand {
   names: string[] | string
   category: string
   minArgs?: number
@@ -9,10 +9,20 @@ export default interface ICommand {
   syntax?: string
   requiredPermissions?: string[]
   callback?: Function
-  cooldown?: string
-  globalCooldown?: string
   ownerOnly?: boolean
   hidden?: boolean
   guildOnly?: boolean
   testOnly?: boolean
 }
+
+interface BaseCommandWithCooldown extends BaseCommand {
+  cooldown?: number
+}
+
+interface BaseCommandWithCooldown extends BaseCommand {
+  globalCooldown?: number
+}
+
+type ICommand = BaseCommandWithCooldown | BaseCommandWithGlobalCooldown
+
+export default ICommand 

--- a/src/interfaces/ICommand.ts
+++ b/src/interfaces/ICommand.ts
@@ -16,11 +16,11 @@ interface BaseCommand {
 }
 
 interface BaseCommandWithCooldown extends BaseCommand {
-  cooldown?: number
+  cooldown?: string
 }
 
 interface BaseCommandWithCooldown extends BaseCommand {
-  globalCooldown?: number
+  globalCooldown?: string
 }
 
 type ICommand = BaseCommandWithCooldown | BaseCommandWithGlobalCooldown


### PR DESCRIPTION
With this interface hierarchy, TypeScript enforces that you can have cooldown or globalCooldown, but not both.