### PR TITLE
Typing for the callback

### DIFF
--- a/src/interfaces/ICommand.ts
+++ b/src/interfaces/ICommand.ts
@@ -1,3 +1,6 @@
+import { Client, Message, PermissionString } from "discord.js"
+import WOKCommands from ".."
+
 export default interface ICommand {
   names: string[] | string
   category: string
@@ -7,8 +10,15 @@ export default interface ICommand {
   expectedArgs?: string
   description?: string
   syntax?: string
-  requiredPermissions?: string[]
-  callback?: Function
+  requiredPermissions?: PermissionString[]
+  callback?: ({ 
+    message: Message, 
+    args: string[], 
+    text: string, 
+    client: Client, 
+    prefix: string, 
+    instance: WOKCommands
+  }) => unknown | Promise<unknown>
   cooldown?: string
   globalCooldown?: string
   ownerOnly?: boolean


### PR DESCRIPTION
The callback could use some typing instead of any Function. I believe this is the correct type for `callback`.

`unknown | Promise<unknown>` means users can use async functions as well and still have type checking.