### PR TITLE
Support ES6 default exports.

### DIFF
--- a/src/CommandHandler.ts
+++ b/src/CommandHandler.ts
@@ -230,7 +230,11 @@ class CommandHandler {
     file: string,
     fileName: string
   ) {
-    const configuration = require(file)
+    let configuration = require(file)
+    
+    // person is using 'export default' so we import the default instead
+    if (configuration.default && Object.keys(configuration).length === 1) configuration = configuration.default
+    
     const {
       name = fileName,
       category,


### PR DESCRIPTION
If the imported command has a default property, and no others, it must be a default export, so we use the `default` property instead.

Original problem: https://discord.com/channels/464316540490088448/785597045699379220/815176765248634890