### PR TITLE
Fully supports Slash Commands, added types

### DIFF
--- a/dist/SlashCommands.js
+++ b/dist/SlashCommands.js
@@ -56,16 +56,27 @@ var SlashCommands = /** @class */ (function () {
         if (listen) {
             // @ts-ignore
             this._client.ws.on("INTERACTION_CREATE", function (interaction) { return __awaiter(_this, void 0, void 0, function () {
-                var member, data, guild_id, channel_id, name, options, command, guild, args, channel;
+                var member, data, guild_id, channel_id, type, user, Appdata, name, options, command, guild, args, channel;
                 return __generator(this, function (_a) {
-                    member = interaction.member, data = interaction.data, guild_id = interaction.guild_id, channel_id = interaction.channel_id;
-                    name = data.name, options = data.options;
-                    command = name.toLowerCase();
-                    guild = this._client.guilds.cache.get(guild_id);
-                    args = this.getArrayFromOptions(guild, options);
-                    channel = guild === null || guild === void 0 ? void 0 : guild.channels.cache.get(channel_id);
-                    this.invokeCommand(interaction, command, args, member, guild, channel);
-                    return [2 /*return*/];
+                    switch (_a.label) {
+                        case 0:
+                            member = interaction.member, data = interaction.data, guild_id = interaction.guild_id, channel_id = interaction.channel_id, type = interaction.type, user = interaction.user;
+                            if (!(type === 1)) return [3 /*break*/, 2];
+                            return [4 /*yield*/, this.createInteractionResponse(interaction, 1)];
+                        case 1:
+                            _a.sent();
+                            return [2 /*return*/];
+                        case 2:
+                            Appdata = data;
+                            name = Appdata.name, options = Appdata.options;
+                            command = name.toLowerCase();
+                            guild = guild_id ? this._client.guilds.cache.get(guild_id) : undefined;
+                            args = this.getArrayFromOptions(guild, options);
+                            channel = channel_id ? guild === null || guild === void 0 ? void 0 : guild.channels.cache.get(channel_id) : undefined;
+                            interaction.channel_type = user ? "DM" : "GUILD";
+                            this.invokeCommand(interaction, command, args, member, guild, channel);
+                            return [2 /*return*/];
+                    }
                 });
             }); });
         }
@@ -154,6 +165,9 @@ var SlashCommands = /** @class */ (function () {
         }
         for (var _i = 0, options_2 = options; _i < options_2.length; _i++) {
             var value = options_2[_i].value;
+            if (!value) {
+                break;
+            }
             args.push(this.getMemberIfExists(value, guild));
         }
         return args;
@@ -175,16 +189,251 @@ var SlashCommands = /** @class */ (function () {
             });
         });
     };
-    SlashCommands.prototype.invokeCommand = function (interaction, commandName, options, member, guild, channel) {
+    SlashCommands.prototype.getInteractionResponseByToken = function (application_id, token) {
         return __awaiter(this, void 0, void 0, function () {
-            var command, result, data, embed;
             return __generator(this, function (_a) {
                 switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.getInteractionResponse({ token: token, application_id: application_id })];
+                    case 1: 
+                    // @ts-ignore
+                    return [2 /*return*/, _a.sent()];
+                }
+            });
+        });
+    };
+    SlashCommands.prototype.deleteInteractionResponseByToken = function (application_id, token) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.deleteInteractionResponse({ token: token, application_id: application_id })];
+                    case 1: 
+                    // @ts-ignore
+                    return [2 /*return*/, _a.sent()];
+                }
+            });
+        });
+    };
+    SlashCommands.prototype.createInteractionResponse = function (interaction, type, data, ephemeral) {
+        return __awaiter(this, void 0, void 0, function () {
+            var Send;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        Send = { type: type };
+                        if (data && ephemeral) {
+                            data.flags = 64;
+                        }
+                        Send.data = data;
+                        return [4 /*yield*/, this._client.api
+                                // @ts-ignore
+                                .interactions(interaction.id, interaction.token)
+                                .callback.post({ data: Send })];
+                    case 1: 
+                    // @ts-ignore
+                    return [2 /*return*/, _a.sent()];
+                }
+            });
+        });
+    };
+    SlashCommands.prototype.getInteractionResponse = function (interaction) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this._client.api
+                            // @ts-ignore
+                            .webhooks(interaction.application_id, interaction.token)
+                            .messages["@original"].get()];
+                    case 1: 
+                    // @ts-ignore
+                    return [2 /*return*/, _a.sent()];
+                }
+            });
+        });
+    };
+    SlashCommands.prototype.editInteractionResponse = function (interaction, data) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this._client.api
+                            // @ts-ignore
+                            .webhooks(interaction.application_id, interaction.token)
+                            .messages["@original"].patch({ data: data })];
+                    case 1: 
+                    // @ts-ignore
+                    return [2 /*return*/, _a.sent()];
+                }
+            });
+        });
+    };
+    //ATTENTION, if the message is ephemeral you can't delete it, only the user who got the message can see and delete it!!
+    SlashCommands.prototype.deleteInteractionResponse = function (interaction) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this._client.api
+                            // @ts-ignore
+                            .webhooks(interaction.application_id, interaction.token)
+                            .messages["@original"].delete()];
+                    case 1: 
+                    // @ts-ignore
+                    return [2 /*return*/, _a.sent()];
+                }
+            });
+        });
+    };
+    SlashCommands.prototype.createFollowupMessage = function (interaction, data, ephemeral) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        if (data && ephemeral) {
+                            data.flags = 64;
+                        }
+                        return [4 /*yield*/, this._client.api
+                                // @ts-ignore
+                                .webhooks(interaction.application_id, interaction.token)
+                                .post({ data: data })];
+                    case 1: 
+                    // @ts-ignore
+                    return [2 /*return*/, _a.sent()];
+                }
+            });
+        });
+    };
+    SlashCommands.prototype.editFollowupMessage = function (interaction, data, message) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this._client.api
+                            // @ts-ignore
+                            .webhooks(interaction.application_id, interaction.token)
+                            .messages(message.id).patch({ data: data })];
+                    case 1: 
+                    // @ts-ignore
+                    return [2 /*return*/, _a.sent()];
+                }
+            });
+        });
+    };
+    //ATTENTION, if the message is ephemeral you can't delete it, only the user who got the message can see and delete it!!
+    SlashCommands.prototype.deleteFollowupMessage = function (interaction, message) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this._client.api
+                            // @ts-ignore
+                            .webhooks(interaction.application_id, interaction.token)
+                            .messages(message.id).delete()];
+                    case 1: 
+                    // @ts-ignore
+                    return [2 /*return*/, _a.sent()];
+                }
+            });
+        });
+    };
+    SlashCommands.prototype.invokeCommand = function (interaction, commandName, options, member, guild, channel) {
+        return __awaiter(this, void 0, void 0, function () {
+            var command, result, patch, embed, _a;
+            var _this = this;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
                     case 0:
                         command = this._instance.commandHandler.getCommand(commandName);
                         if (!command || !command.callback) {
                             return [2 /*return*/, false];
                         }
+                        interaction.status = {};
+                        interaction.delete = function () { return __awaiter(_this, void 0, void 0, function () {
+                            var respond;
+                            return __generator(this, function (_a) {
+                                switch (_a.label) {
+                                    case 0: return [4 /*yield*/, this.deleteInteractionResponse(interaction)];
+                                    case 1:
+                                        respond = _a.sent();
+                                        interaction.status.deletet = true;
+                                        return [2 /*return*/, respond];
+                                }
+                            });
+                        }); };
+                        interaction.loading = function () { return __awaiter(_this, void 0, void 0, function () {
+                            var respond, respondMessage;
+                            return __generator(this, function (_a) {
+                                switch (_a.label) {
+                                    case 0: return [4 /*yield*/, this.createInteractionResponse(interaction, 5)];
+                                    case 1:
+                                        respond = _a.sent();
+                                        interaction.status.loaded = true;
+                                        return [4 /*yield*/, this.getInteractionResponse(interaction)];
+                                    case 2:
+                                        respondMessage = _a.sent();
+                                        return [2 /*return*/, respondMessage];
+                                }
+                            });
+                        }); };
+                        interaction.reply = function (data) { return __awaiter(_this, void 0, void 0, function () {
+                            var DataToSend, respond, DataToSend, respond, respondMessage;
+                            return __generator(this, function (_a) {
+                                switch (_a.label) {
+                                    case 0:
+                                        if (!interaction.status.loaded) return [3 /*break*/, 2];
+                                        DataToSend = void 0;
+                                        //TODO enable support for also passing an embed as data
+                                        if (typeof data === "string") {
+                                            DataToSend = { content: data };
+                                        }
+                                        else {
+                                            DataToSend = data;
+                                        }
+                                        return [4 /*yield*/, this.editInteractionResponse(interaction, DataToSend)];
+                                    case 1:
+                                        respond = _a.sent();
+                                        interaction.status.send = true;
+                                        return [2 /*return*/, respond];
+                                    case 2:
+                                        if (!!interaction.status.send) return [3 /*break*/, 5];
+                                        DataToSend = void 0;
+                                        //TODO enable support for also passing an embed as data
+                                        if (typeof data === "string") {
+                                            DataToSend = { content: data };
+                                        }
+                                        else {
+                                            DataToSend = data;
+                                        }
+                                        return [4 /*yield*/, this.createInteractionResponse(interaction, 4, DataToSend)];
+                                    case 3:
+                                        respond = _a.sent();
+                                        interaction.status.send = true;
+                                        return [4 /*yield*/, this.getInteractionResponse(interaction)];
+                                    case 4:
+                                        respondMessage = _a.sent();
+                                        return [2 /*return*/, respondMessage];
+                                    case 5:
+                                        console.error("WOKCommands > Interaction \"" + interaction.id + "\" loaded and send the message already");
+                                        return [2 /*return*/, Promise.reject("WOKCommands > Interaction \"" + interaction.id + "\" loaded and send the message already")];
+                                }
+                            });
+                        }); };
+                        interaction.edit = function (data) { return __awaiter(_this, void 0, void 0, function () {
+                            var DataToSend, respond;
+                            return __generator(this, function (_a) {
+                                switch (_a.label) {
+                                    case 0:
+                                        //TODO enable support for also passing an embed as data
+                                        if (typeof data === "string") {
+                                            DataToSend = { content: data };
+                                        }
+                                        else {
+                                            DataToSend = data;
+                                        }
+                                        return [4 /*yield*/, this.editInteractionResponse(interaction, DataToSend)];
+                                    case 1:
+                                        respond = _a.sent();
+                                        interaction.status.send = true;
+                                        return [2 /*return*/, respond];
+                                }
+                            });
+                        }); };
+                        interaction.followUpMessages = { create: this.createFollowupMessage, delete: this.deleteFollowupMessage, edit: this.editFollowupMessage };
                         return [4 /*yield*/, command.callback({
                                 member: member,
                                 guild: guild,
@@ -197,31 +446,40 @@ var SlashCommands = /** @class */ (function () {
                                 interaction: interaction,
                             })];
                     case 1:
-                        result = _a.sent();
-                        if (!result) {
-                            console.error("WOKCommands > Command \"" + commandName + "\" did not return any content from it's callback function. This is required as it is a slash command.");
+                        result = _b.sent();
+                        if (interaction.status.send) {
+                            return [2 /*return*/, true];
+                        }
+                        if (interaction.status.loaded) {
+                            console.error("WOKCommands > Command \"" + commandName + "\" used loading, but not send, thats a mi of old and new methods, switch fully to the new ones to fix this");
                             return [2 /*return*/, false];
                         }
-                        data = {
-                            content: result,
-                        };
+                        if (!result && !interaction.status.send) {
+                            console.error("WOKCommands > Command \"" + commandName + "\" didn't send anything, and didn't return a value as fallback action");
+                            return [2 /*return*/, false];
+                        }
+                        if (interaction.status.deletet && result) {
+                            console.error("WOKCommands > Command \"" + commandName + "\" the interaction response was already deletet");
+                            return [2 /*return*/, false];
+                        }
+                        if (result) {
+                            console.warn("WOKCommands > Command \"" + commandName + "\" returned something from the callback, this is deprecated and will be removed later on");
+                        }
+                        patch = {};
                         if (!(typeof result === "object")) return [3 /*break*/, 3];
                         embed = new discord_js_1.MessageEmbed(result);
+                        // @ts-ignore
+                        _a = patch;
                         return [4 /*yield*/, this.createAPIMessage(interaction, embed)];
                     case 2:
-                        data = _a.sent();
-                        _a.label = 3;
-                    case 3:
                         // @ts-ignore
-                        this._client.api
-                            // @ts-ignore
-                            .interactions(interaction.id, interaction.token)
-                            .callback.post({
-                            data: {
-                                type: 4,
-                                data: data,
-                            },
-                        });
+                        _a.embeds = [(_b.sent())];
+                        return [3 /*break*/, 4];
+                    case 3:
+                        patch.content = result;
+                        _b.label = 4;
+                    case 4:
+                        this.createInteractionResponse(interaction, 4, patch);
                         return [2 /*return*/, true];
                 }
             });

--- a/dist/types/Interaction.js
+++ b/dist/types/Interaction.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/src/SlashCommands.ts
+++ b/src/SlashCommands.ts
@@ -1,15 +1,23 @@
 import {
   APIMessage,
-  APIMessageContentResolvable,
+  Message,
   Channel,
   Client,
   Guild,
   GuildMember,
   MessageEmbed,
+  Snowflake
 } from "discord.js";
 import WOKCommands from ".";
 import ISlashCommand from "./interfaces/ISlashCommand";
-
+import {Interaction,
+  InteractionApplicationCommandCallbackData,
+  ApplicationCommandInteractionData,
+  ApplicationCommandInteractionDataOption,
+  InteractionResponse,InteractionCallbackType,
+  EditWebhookMessage,
+  ExecuteWebhook
+} from "./types/Interaction";
 class SlashCommands {
   private _client: Client;
   private _instance: WOKCommands;
@@ -20,14 +28,22 @@ class SlashCommands {
 
     if (listen) {
       // @ts-ignore
-      this._client.ws.on("INTERACTION_CREATE", async (interaction) => {
-        const { member, data, guild_id, channel_id } = interaction;
-        const { name, options } = data;
-
+      this._client.ws.on("INTERACTION_CREATE", async (interaction:Interaction) => {
+        const { member, data, guild_id, channel_id,type,user } = interaction;
+        //type === 1 is the ping request from discord, I don't know if discord ever makes one, but if so, we respond automatically
+        if(type===1){
+          await this.createInteractionResponse(interaction,1)
+          return;
+        }
+        // if type !== 1 data is always present!!
+        const Appdata:ApplicationCommandInteractionData=data!!;
+        const { name, options } = Appdata;
+        
         const command = name.toLowerCase();
-        const guild = this._client.guilds.cache.get(guild_id);
+        const guild = guild_id?this._client.guilds.cache.get(guild_id):undefined;
         const args = this.getArrayFromOptions(guild, options);
-        const channel = guild?.channels.cache.get(channel_id);
+        const channel = channel_id?guild?.channels.cache.get(channel_id):undefined;
+        interaction.channel_type=user?"DM":"GUILD";
         this.invokeCommand(interaction, command, args, member, guild, channel);
       });
     }
@@ -92,7 +108,7 @@ class SlashCommands {
 
   public getObjectFromOptions(
     guild: { members: { cache: any } },
-    options?: { name: string; value: string }[]
+    options?: [ApplicationCommandInteractionDataOption]
   ): Object {
     const args: { [key: string]: any } = {};
     if (!options) {
@@ -100,7 +116,7 @@ class SlashCommands {
     }
 
     for (const { name, value } of options) {
-      args[name] = this.getMemberIfExists(value, guild);
+      args[name] = this.getMemberIfExists(value!!, guild);
     }
 
     return args;
@@ -108,7 +124,7 @@ class SlashCommands {
 
   public getArrayFromOptions(
     guild: { members: { cache: any } } | undefined,
-    options?: { name: string; value: string }[]
+    options?: [ApplicationCommandInteractionDataOption]
   ): string[] {
     const args: string[] = [];
     if (!options) {
@@ -116,6 +132,9 @@ class SlashCommands {
     }
 
     for (const { value } of options) {
+      if(!value){
+        break;
+      }
       args.push(this.getMemberIfExists(value, guild));
     }
 
@@ -123,9 +142,9 @@ class SlashCommands {
   }
 
   public async createAPIMessage(
-    interaction: APIMessageContentResolvable,
+    interaction: Interaction,
     content: any
-  ) {
+  ):Promise<object> {
     const { data, files } = await APIMessage.create(
       // @ts-ignore
       this._client.channels.resolve(interaction.channel_id),
@@ -137,11 +156,80 @@ class SlashCommands {
     return { ...data, files };
   }
 
+  public async getInteractionResponseByToken(application_id: Snowflake,token:string): Promise<Message> {
+    // @ts-ignore
+    return await this.getInteractionResponse({token,application_id})
+  }
+  public async deleteInteractionResponseByToken(application_id: Snowflake,token:string): Promise<Buffer> {
+    // @ts-ignore
+    return await this.deleteInteractionResponse({token,application_id})
+  }
+
+  private async createInteractionResponse(interaction: Interaction, type: InteractionCallbackType,data?: InteractionApplicationCommandCallbackData,ephemeral?:boolean): Promise<Buffer> {
+    let Send:InteractionResponse={type}
+    if(data&&ephemeral){
+      data.flags=64;
+    }
+    Send.data=data;
+    // @ts-ignore
+    return await this._client.api
+    // @ts-ignore
+    .interactions(interaction.id, interaction.token)
+    .callback.post({data:Send});
+  }
+  private async getInteractionResponse(interaction: Interaction): Promise<Message> {
+    // @ts-ignore
+    return await this._client.api
+    // @ts-ignore
+    .webhooks(interaction.application_id, interaction.token)
+    .messages["@original"].get();
+  }
+  private async editInteractionResponse(interaction: Interaction, data: EditWebhookMessage): Promise<Message> {
+    // @ts-ignore
+    return await  this._client.api
+   // @ts-ignore
+    .webhooks(interaction.application_id, interaction.token)
+    .messages["@original"].patch({data});
+  }
+  //ATTENTION, if the message is ephemeral you can't delete it, only the user who got the message can see and delete it!!
+  private async deleteInteractionResponse(interaction: Interaction): Promise<Buffer> {
+    // @ts-ignore
+    return await this._client.api
+    // @ts-ignore
+    .webhooks(interaction.application_id, interaction.token)
+    .messages["@original"].delete();
+  }
+  private async createFollowupMessage(interaction: Interaction, data:ExecuteWebhook,ephemeral?:boolean): Promise<Message> {
+    if(data&&ephemeral){
+      data.flags=64;
+    }
+    // @ts-ignore
+    return await this._client.api
+    // @ts-ignore
+    .webhooks(interaction.application_id,interaction.token)
+    .post({data});
+  }
+  private async editFollowupMessage(interaction: Interaction, data: EditWebhookMessage, message:Message): Promise<Message> {
+    // @ts-ignore
+    return await  this._client.api
+   // @ts-ignore
+    .webhooks(interaction.application_id, interaction.token)
+    .messages(message.id).patch({data});
+  }
+  //ATTENTION, if the message is ephemeral you can't delete it, only the user who got the message can see and delete it!!
+  private async deleteFollowupMessage(interaction: Interaction, message:Message): Promise<Buffer> {
+    // @ts-ignore
+    return await this._client.api
+    // @ts-ignore
+    .webhooks(interaction.application_id, interaction.token)
+    .messages(message.id).delete();
+  }
+
   public async invokeCommand(
-    interaction: APIMessageContentResolvable,
+    interaction: Interaction,
     commandName: string,
     options: object,
-    member: GuildMember,
+    member: GuildMember | undefined,
     guild: Guild | undefined,
     channel: Channel | undefined
   ): Promise<boolean> {
@@ -150,6 +238,63 @@ class SlashCommands {
     if (!command || !command.callback) {
       return false;
     }
+    interaction.status={};
+    interaction.delete = async ():Promise<Buffer>=>{
+      let respond = await this.deleteInteractionResponse(interaction)
+      interaction.status.deletet=true;
+      return respond;
+  }
+    interaction.loading = async ():Promise<Message>=>{
+        let respond = await this.createInteractionResponse(interaction,5)
+        interaction.status.loaded=true;
+        let respondMessage = await this.getInteractionResponse(interaction)
+        return respondMessage;
+    }
+    interaction.reply=async(data:InteractionApplicationCommandCallbackData | string):Promise<Message>=>{
+      if(interaction.status.loaded){
+        let DataToSend:EditWebhookMessage ;
+        //TODO enable support for also passing an embed as data
+        if (typeof data === "string") {
+          DataToSend={content:data}
+        }else{
+          DataToSend=data
+        }
+        let respond = await this.editInteractionResponse(interaction,DataToSend)
+        interaction.status.send=true;
+        return respond;
+      }else if(!interaction.status.send){
+        let DataToSend:InteractionApplicationCommandCallbackData ;
+         //TODO enable support for also passing an embed as data
+        if (typeof data === "string") {
+          DataToSend={content:data}
+        }else{
+          DataToSend=data
+        }
+        let respond = await this.createInteractionResponse(interaction,4,DataToSend)
+        interaction.status.send=true;
+        let respondMessage = await this.getInteractionResponse(interaction)
+        return respondMessage;
+      }else{
+        console.error(
+          `WOKCommands > Interaction "${interaction.id}" loaded and send the message already`
+        );
+        return Promise.reject(`WOKCommands > Interaction "${interaction.id}" loaded and send the message already`);
+      }
+    }
+      interaction.edit=async(data:InteractionApplicationCommandCallbackData | string):Promise<Message>=>{
+          let DataToSend:EditWebhookMessage ;
+          //TODO enable support for also passing an embed as data
+          if (typeof data === "string") {
+            DataToSend={content:data}
+          }else{
+            DataToSend=data
+          }
+          let respond = await this.editInteractionResponse(interaction,DataToSend)
+          interaction.status.send=true;
+          return respond;
+      }
+      
+    interaction.followUpMessages={create:this.createFollowupMessage,delete:this.deleteFollowupMessage,edit:this.editFollowupMessage};
 
     let result = await command.callback({
       member,
@@ -163,34 +308,46 @@ class SlashCommands {
       interaction,
     });
 
-    if (!result) {
+    if(interaction.status.send){
+      return true;
+    }
+    if(interaction.status.loaded){
       console.error(
-        `WOKCommands > Command "${commandName}" did not return any content from it's callback function. This is required as it is a slash command.`
+        `WOKCommands > Command "${commandName}" used loading, but not send, thats a mi of old and new methods, switch fully to the new ones to fix this`
       );
       return false;
     }
 
-    let data: any = {
-      content: result,
-    };
+    if (!result&&!interaction.status.send) {
+      console.error(
+        `WOKCommands > Command "${commandName}" didn't send anything, and didn't return a value as fallback action`
+      );
+      return false;
+    }
 
+    if(interaction.status.deletet&&result){
+      console.error(
+        `WOKCommands > Command "${commandName}" the interaction response was already deletet`
+      );
+      return false;
+    }
+
+    if (result) {
+      console.warn(
+        `WOKCommands > Command "${commandName}" returned something from the callback, this is deprecated and will be removed later on`
+      );
+    }
+
+    let patch: InteractionApplicationCommandCallbackData = {}
     // Handle embeds
     if (typeof result === "object") {
       const embed = new MessageEmbed(result);
-      data = await this.createAPIMessage(interaction, embed);
+       // @ts-ignore
+      patch.embeds = [(await this.createAPIMessage(interaction, embed))];
+    }else{
+      patch.content= result;
     }
-
-    // @ts-ignore
-    this._client.api
-      // @ts-ignore
-      .interactions(interaction.id, interaction.token)
-      .callback.post({
-        data: {
-          type: 4,
-          data,
-        },
-      });
-
+    this.createInteractionResponse(interaction,4,patch)
     return true;
   }
 }

--- a/src/types/Interaction.ts
+++ b/src/types/Interaction.ts
@@ -1,0 +1,112 @@
+import { Snowflake,User,MessageMentionOptions,MessageEmbed ,GuildMember,Role,Channel,MessageAttachment,FileOptions,Message} from "discord.js";
+//Discord.js doesn't support these types, so they had to be added, note not all types are fully tested
+export type ApplicationCommandInteractionData = {
+    id:Snowflake;
+    name:string;
+    resolved?:ApplicationCommandInteractionDataResolved;
+    options?:[ApplicationCommandInteractionDataOption];
+
+}
+
+export type ApplicationCommandInteractionDataResolved = {
+    users?:{ID:number,User:User};
+    members?:{ID:number,Member:GuildMember}; //Partial Member objects are missing user, deaf and mute fields
+    roles?:{ID:number,Role:Role};
+    channels?:{ID:number,Channel:Channel}; // Partial Channel objects only have id, name, type and permissions fields
+}
+
+
+
+export type ApplicationCommandOptionType_value = 1 | 2 | 3 | 4 | 5 |6 | 7 | 8 | 9;
+export type ApplicationCommandOptionType = {
+    name: ("SUB_COMMAND" | 
+    "SUB_COMMAND_GROUP" | 
+    "STRING" | 
+    "INTEGER" | 
+    "BOOLEAN" | 
+    "USER_BANNED" | 
+    "CHANNEL" | 
+    "ROLE" | 
+    "MENTIONABLE");
+    value:ApplicationCommandOptionType_value
+}
+
+export type ApplicationCommandInteractionDataOption = {
+name:string;
+type:ApplicationCommandOptionType_value;
+value?:string;
+options?:[ApplicationCommandInteractionDataOption];
+}
+
+export type InteractionType = 1 | 2;  //1 = Ping, 2 = ApplicationCommand
+
+
+export type ChannelType =  "DM" | "GUILD";
+
+export type Interaction = {
+    id: Snowflake;
+    application_id: Snowflake;
+    type: 	InteractionType;
+    data?:	ApplicationCommandInteractionData;
+    guild_id?:Snowflake;
+    channel_id?:Snowflake;
+    member?:GuildMember;
+    user?:User;
+    token:string;
+    version:number;
+    //custom properties
+    channel_type:ChannelType;
+    status:{
+        loaded?:boolean;
+        send?:boolean;
+        deletet?:boolean;
+    };
+    reply?(data:InteractionApplicationCommandCallbackData| string): Promise<Message>;
+    loading?(): Promise<Message>;
+    edit?(data:InteractionApplicationCommandCallbackData| string): Promise<Message>;
+    delete?():Promise<Buffer>;
+    followUpMessages?:{
+        create(interaction: Interaction, data:ExecuteWebhook,ephemeral?:boolean):Promise<Message>;
+        delete(interaction: Interaction, message:Message):Promise<Buffer>;
+        edit(interaction: Interaction, data: EditWebhookMessage, message:Message):Promise<Message>;
+    }
+}  
+
+export type InteractionApplicationCommandCallbackData = {
+    tts?:boolean;
+    content?:string;
+    embeds?:[MessageEmbed]; //max 10 !!!
+    allowed_mentions?:MessageMentionOptions;
+    flags?:number;
+
+
+}
+
+export type InteractionCallbackType = 1 | 4 | 5; // 1  Pong, 4 = ChannelMessageWithSource, 5  =  DeferredChannelMessageWithSource;
+export type InteractionResponse = {
+    type:InteractionCallbackType;
+    data?:InteractionApplicationCommandCallbackData;
+}
+
+
+export type EditWebhookMessage = {
+    content?:string;
+    embeds?:[MessageEmbed]; //max 10 !!!
+    file?:(MessageAttachment | FileOptions | string);
+    payload_json?:string;
+    allowed_mentions?:MessageMentionOptions;
+    attachments?:[MessageAttachment];
+}
+
+
+export type ExecuteWebhook = {
+    content?:string;
+    username?:string;
+    avatar_url?:string;
+    tts?:boolean;
+    embeds?:[MessageEmbed]; //max 10 !!!
+    file?:(MessageAttachment | FileOptions | string);
+    payload_json?:string;
+    allowed_mentions?:MessageMentionOptions;
+    flags?:number;
+}


### PR DESCRIPTION
I accedentely submittet another pull request right on top of that, but I added the Slash commands Feature, so its fully supported, I tested every function with proper data, and it works, the implemementation is according to the docs of discord, its supports ephemeral messages, followup messages and so on. However the implementation of adding properties to the interaction object given to the callback of commands is discussable, but I personally would use it like this. Single pulll request from previous #90 