### PR TITLE
Add argType option to CommandHandler

### DIFF
--- a/dist/CommandHandler.js
+++ b/dist/CommandHandler.js
@@ -435,7 +435,7 @@ var CommandHandler = /** @class */ (function () {
                         if (minArgs !== undefined && !expectedArgs) {
                             throw new Error("WOKCommands > Command \"" + names[0] + "\" has \"minArgs\" property defined without \"expectedArgs\" property as a slash command.");
                         }
-                        if (argTypes !== undefined && argTypes.map(function (arg) { return typeof arg !== 'number'; }).reduce(function (a, b) { return a || b; })) {
+                        if (argTypes !== undefined && !Array.isArray(argTypes) || argTypes.map(function (arg) { return typeof arg !== 'number'; }).reduce(function (a, b) { return a || b; })) {
                             throw new Error("WOKCommands > \"argTypes\" option must be an array of numbers");
                         }
                         slashCommands = instance.slashCommands;

--- a/dist/CommandHandler.js
+++ b/dist/CommandHandler.js
@@ -435,7 +435,7 @@ var CommandHandler = /** @class */ (function () {
                         if (minArgs !== undefined && !expectedArgs) {
                             throw new Error("WOKCommands > Command \"" + names[0] + "\" has \"minArgs\" property defined without \"expectedArgs\" property as a slash command.");
                         }
-                        if (argTypes !== undefined && argTypes.map(function (arg) { return typeof arg === 'number'; }).reduce(function (a, b) { return a && b; })) {
+                        if (argTypes !== undefined && argTypes.map(function (arg) { return typeof arg !== 'number'; }).reduce(function (a, b) { return a || b; })) {
                             throw new Error("WOKCommands > \"argTypes\" option must be an array of numbers");
                         }
                         slashCommands = instance.slashCommands;

--- a/dist/CommandHandler.js
+++ b/dist/CommandHandler.js
@@ -371,7 +371,7 @@ var CommandHandler = /** @class */ (function () {
     }
     CommandHandler.prototype.registerCommand = function (instance, client, file, fileName) {
         return __awaiter(this, void 0, void 0, function () {
-            var configuration, _a, name, category, commands, aliases, init, callback, execute, run, error, description, requiredPermissions, permissions, testOnly, slash, expectedArgs, minArgs, callbackCounter, names, _i, _b, perm, missing, slashCommands, options, split, a, item, _c, _d, id, hasCallback, command, _e, names_1, name_2;
+            var configuration, _a, name, argTypes, category, commands, aliases, init, callback, execute, run, error, description, requiredPermissions, permissions, testOnly, slash, expectedArgs, minArgs, callbackCounter, names, _i, _b, perm, missing, slashCommands, options, split, a, item, _c, _d, id, hasCallback, command, _e, names_1, name_2;
             return __generator(this, function (_f) {
                 switch (_f.label) {
                     case 0:
@@ -380,7 +380,7 @@ var CommandHandler = /** @class */ (function () {
                         if (configuration.default && Object.keys(configuration).length === 1) {
                             configuration = configuration.default;
                         }
-                        _a = configuration.name, name = _a === void 0 ? fileName : _a, category = configuration.category, commands = configuration.commands, aliases = configuration.aliases, init = configuration.init, callback = configuration.callback, execute = configuration.execute, run = configuration.run, error = configuration.error, description = configuration.description, requiredPermissions = configuration.requiredPermissions, permissions = configuration.permissions, testOnly = configuration.testOnly, slash = configuration.slash, expectedArgs = configuration.expectedArgs, minArgs = configuration.minArgs;
+                        _a = configuration.name, name = _a === void 0 ? fileName : _a, argTypes = configuration.argTypes, category = configuration.category, commands = configuration.commands, aliases = configuration.aliases, init = configuration.init, callback = configuration.callback, execute = configuration.execute, run = configuration.run, error = configuration.error, description = configuration.description, requiredPermissions = configuration.requiredPermissions, permissions = configuration.permissions, testOnly = configuration.testOnly, slash = configuration.slash, expectedArgs = configuration.expectedArgs, minArgs = configuration.minArgs;
                         callbackCounter = 0;
                         if (callback)
                             ++callbackCounter;
@@ -435,6 +435,9 @@ var CommandHandler = /** @class */ (function () {
                         if (minArgs !== undefined && !expectedArgs) {
                             throw new Error("WOKCommands > Command \"" + names[0] + "\" has \"minArgs\" property defined without \"expectedArgs\" property as a slash command.");
                         }
+                        if (argTypes !== undefined && argTypes.map(function (arg) { return typeof arg === 'number'; }).reduce(function (a, b) { return a && b; })) {
+                            throw new Error("WOKCommands > \"argTypes\" option must be an array of numbers");
+                        }
                         slashCommands = instance.slashCommands;
                         options = [];
                         if (expectedArgs) {
@@ -446,7 +449,7 @@ var CommandHandler = /** @class */ (function () {
                                 options.push({
                                     name: item.replace(/ /g, "-"),
                                     description: item,
-                                    type: 3,
+                                    type: argTypes !== undefined && argTypes[a] !== undefined ? argTypes[a] : 3,
                                     required: a < minArgs,
                                 });
                             }

--- a/src/CommandHandler.ts
+++ b/src/CommandHandler.ts
@@ -390,6 +390,7 @@ class CommandHandler {
 
     const {
       name = fileName,
+      argTypes,
       category,
       commands,
       aliases,
@@ -493,6 +494,12 @@ class CommandHandler {
         );
       }
 
+      if (argTypes !== undefined && argTypes.map(arg => typeof arg === 'number').reduce((a,b) => a && b)){
+        throw new Error(
+          `WOKCommands > "argTypes" option must be an array of numbers`
+        );
+      }
+
       const slashCommands = instance.slashCommands;
       const options: object[] = [];
 
@@ -507,7 +514,7 @@ class CommandHandler {
           options.push({
             name: item.replace(/ /g, "-"),
             description: item,
-            type: 3,
+            type: argTypes !== undefined && argTypes[a] !== undefined ? argTypes[a] : 3,
             required: a < minArgs,
           });
         }

--- a/src/CommandHandler.ts
+++ b/src/CommandHandler.ts
@@ -494,7 +494,7 @@ class CommandHandler {
         );
       }
 
-      if (argTypes !== undefined && argTypes.map(arg => typeof arg === 'number').reduce((a,b) => a && b)){
+      if (argTypes !== undefined && argTypes.map(arg => typeof arg !== 'number').reduce((a,b) => a || b)){
         throw new Error(
           `WOKCommands > "argTypes" option must be an array of numbers`
         );

--- a/src/CommandHandler.ts
+++ b/src/CommandHandler.ts
@@ -494,7 +494,7 @@ class CommandHandler {
         );
       }
 
-      if (argTypes !== undefined && argTypes.map(arg => typeof arg !== 'number').reduce((a,b) => a || b)){
+      if (argTypes !== undefined && !Array.isArray(argTypes) || argTypes.map(arg => typeof arg !== 'number').reduce((a,b) => a || b)){
         throw new Error(
           `WOKCommands > "argTypes" option must be an array of numbers`
         );


### PR DESCRIPTION
Adds optional `argType` option to commands. `argType` is an array of numbers representing the [Command Option Type](https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-option-type). Before, all options were of type string (3).