### PR TITLE
Slash command argument choices support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.6",
   "main": "dist/index.js",
   "scripts": {
-    "compile": "tsc && node index.js",
+    "compile": "tsc && node dist/index.js",
     "dev": "nodemon -e ts --exec \"npm run compile\""
   },
   "keywords": [],

--- a/src/CommandHandler.ts
+++ b/src/CommandHandler.ts
@@ -404,6 +404,7 @@ class CommandHandler {
       testOnly,
       slash,
       expectedArgs,
+      argChoices,
       minArgs,
     } = configuration;
 
@@ -504,12 +505,34 @@ class CommandHandler {
         for (let a = 0; a < split.length; ++a) {
           const item = split[a];
 
-          options.push({
+          type Option = {
+            name: string,
+            description: string,
+            type: number,
+            required: boolean,
+            choices?: Array<OptionChoices>
+          }
+
+          type OptionChoices = {
+            name: string,
+            value: string
+          };
+
+          const option: Option = {
             name: item.replace(/ /g, "-"),
             description: item,
             type: 3,
             required: a < minArgs,
-          });
+          };
+
+          if (Object.keys(argChoices).includes(item)) {
+            const choices = argChoices[item];
+            if (choices.length) {
+              option.choices = choices;
+            }
+          }
+          
+          options.push(option);
         }
       }
 


### PR DESCRIPTION
Nice package....

I noticed the `npm run compile` will fail to load with nodemon since it was set to look at the root folder for the generated `index.js`. I was getting a `MODULE_NOT_FOUND` from nodemon. I changed the script to look at `dist/index.js` where the generated transpiled JavaScript index.js is saved. This resolved that issue.

On a secondary note:

I made a minor upgrade to support the Slash commands argument choices....This enables the ability to have specific choices that the user can select from during the slash command auto-complete...

Below is an example of how `commands/ping.js` looks with the new `argChoices` setting I added.

```javascript
const { MessageEmbed } = require("discord.js");

module.exports = {
  slash: true,
  testOnly: true,
  description: "A simple ping pong command!!!",
  minArgs: 2,
  expectedArgs: "<name> <age> [country]",
  argChoices: {
    name: [
      {
        name: "Bobby",
        value: "name_bobby",
      },
      {
        name: "Sally",
        value: "name_sally",
      },
      {
        name: "Johnny",
        value: "name_johnny",
      },
    ],
  },
  callback: ({ args }) => {
    const [name, age, country] = args;
    return new MessageEmbed()
      .setTitle("Example")
      .setDescription("pong")
      .addField("Name", name)
      .addField("Age", age)
      .addField("Country", country || "None");
  },
};
```