### PR TITLE
make help command a slash command

### DIFF
--- a/dist/commands/help/help.js
+++ b/dist/commands/help/help.js
@@ -40,6 +40,7 @@ module.exports = {
     category: 'Help',
     aliases: 'commands',
     maxArgs: 1,
+    slash: 'both',
     expectedArgs: '[command]',
     init: (client, instance) => {
         client.on('messageReactionAdd', async (reaction, user) => {


### PR DESCRIPTION
(and also still a legacy command)
not quite sure why this wasn't done before...