### PR TITLE
Update !get-first-embed.js

### DIFF
--- a/dist/commands/help/!get-first-embed.js
+++ b/dist/commands/help/!get-first-embed.js
@@ -7,7 +7,7 @@ const getFirstEmbed = (message, instance) => {
     const embed = new discord_js_1.MessageEmbed()
         .setTitle(`${instance.displayName} ${messageHandler.getEmbed(guild, 'HELP_MENU', 'TITLE')}`)
         .setDescription(messageHandler.getEmbed(guild, 'HELP_MENU', 'SELECT_A_CATEGORY'))
-        .setFooter(`ID #${message.author?.id}`);
+        .setFooter({text: `ID #${message.author?.id}`});
     if (instance.color) {
         embed.setColor(instance.color);
     }


### PR DESCRIPTION
Avoid to "DeprecationWarning: Passing strings for MessageEmbed#setFooter is deprecated. Pass a sole object instead.
(Use `node --trace-deprecation ...` to show where the warning was created)"