### PR TITLE
Add support for .cjs files

### DIFF
--- a/src/get-all-files.ts
+++ b/src/get-all-files.ts
@@ -10,7 +10,7 @@ const getAllFiles = (dir: string, extension?: string) => {
     if (file.isDirectory()) {
       jsFiles = [...jsFiles, ...getAllFiles(`${dir}/${file.name}`, extension)]
     } else if (
-      file.name.endsWith(extension || '.js') &&
+      (file.name.endsWith(extension || '.js') || file.name.endsWith('.cjs')) &&
       !file.name.startsWith('!')
     ) {
       let fileName: string | string[] = file.name.replace(/\\/g, '/').split('/')


### PR DESCRIPTION
Currently, WOKC only auto-imports commands of files that end with `.js` with the WOKC option `typescript: false`. With the small change below, CommonJS files `.cjs` will be imported as well in case the project package has the option `"type": "module"`.

Edit: seems I forgot to switch to merge into [AlexzanderFlores:dev](https://github.com/AlexzanderFlores/WOKCommands/tree/dev) instead of [_:main](https://github.com/AlexzanderFlores/WOKCommands) and I can't edit this (I think). Either branch is fine with me, as long as it is released in the near future.

@AlexzanderFlores Seeing the number of issues and open pull-up requests, is this repository abandoned? If so, could you give someone (trustful) write access to both the dev and main branch?