### PR TITLE
Add other logging methods

### DIFF
--- a/dist/Command.js
+++ b/dist/Command.js
@@ -210,7 +210,7 @@ class Command {
             (this._cooldownChar === 'm' && this._cooldownDuration >= 5)) {
             this._databaseCooldown = true;
             if (!this.instance.isDBConnected()) {
-                console.warn(`WOKCommands > A database connection is STRONGLY RECOMMENDED for cooldowns of 5 minutes or more.`);
+                this.instance.warn(`WOKCommands > A database connection is STRONGLY RECOMMENDED for cooldowns of 5 minutes or more.`);
             }
         }
     }

--- a/dist/CommandHandler.js
+++ b/dist/CommandHandler.js
@@ -48,23 +48,23 @@ class CommandHandler {
     }
     async setUp(instance, client, dir, disabledDefaultCommands, typeScript = false) {
         // Do not pass in TS here because this should always compiled to JS
-        for (const [file, fileName] of get_all_files_1.default(path_1.default.join(__dirname, 'commands'))) {
+        for (const [file, fileName] of (0, get_all_files_1.default)(path_1.default.join(__dirname, 'commands'))) {
             if (disabledDefaultCommands.includes(fileName)) {
                 continue;
             }
             await this.registerCommand(instance, client, file, fileName, true);
         }
         // Do not pass in TS here because this should always compiled to JS
-        for (const [file, fileName] of get_all_files_1.default(path_1.default.join(__dirname, 'command-checks'))) {
+        for (const [file, fileName] of (0, get_all_files_1.default)(path_1.default.join(__dirname, 'command-checks'))) {
             this._commandChecks.set(fileName, require(file));
         }
         if (dir) {
             if (!fs_1.default.existsSync(dir)) {
                 throw new Error(`Commands directory "${dir}" doesn't exist!`);
             }
-            const files = get_all_files_1.default(dir, typeScript ? '.ts' : '');
+            const files = (0, get_all_files_1.default)(dir, typeScript ? '.ts' : '');
             const amount = files.length;
-            console.log(`WOKCommands > Loaded ${amount} command${amount === 1 ? '' : 's'}.`);
+            instance.log(`WOKCommands > Loaded ${amount} command${amount === 1 ? '' : 's'}.`);
             for (const [file, fileName] of files) {
                 await this.registerCommand(instance, client, file, fileName);
             }
@@ -138,7 +138,7 @@ class CommandHandler {
                     }
                     else {
                         message.reply(instance.messageHandler.get(guild, 'EXCEPTION'));
-                        console.error(e);
+                        instance.error(e);
                     }
                     instance.emit(Events_1.default.COMMAND_EXCEPTION, command, message, e);
                 }
@@ -193,10 +193,10 @@ class CommandHandler {
             missing.push('Description');
         }
         if (missing.length && instance.showWarns) {
-            console.warn(`WOKCommands > Command "${names[0]}" does not have the following properties: ${missing}.`);
+            instance.warn(`WOKCommands > Command "${names[0]}" does not have the following properties: ${missing}.`);
         }
         if (testOnly && !instance.testServers.length) {
-            console.warn(`WOKCommands > Command "${names[0]}" has "testOnly" set to true, but no test servers are defined.`);
+            instance.warn(`WOKCommands > Command "${names[0]}" has "testOnly" set to true, but no test servers are defined.`);
         }
         if (slash !== undefined && typeof slash !== 'boolean' && slash !== 'both') {
             throw new Error(`WOKCommands > Command "${names[0]}" has a "slash" property that is not boolean "true" or string "both".`);
@@ -216,11 +216,11 @@ class CommandHandler {
                     const name = options[key].name;
                     let lowerCase = name.toLowerCase();
                     if (name !== lowerCase && instance.showWarns) {
-                        console.log(`WOKCommands > Command "${names[0]}" has an option of "${name}". All option names must be lower case for slash commands. WOKCommands will modify this for you.`);
+                        instance.log(`WOKCommands > Command "${names[0]}" has an option of "${name}". All option names must be lower case for slash commands. WOKCommands will modify this for you.`);
                     }
                     if (lowerCase.match(/\s/g)) {
                         lowerCase = lowerCase.replace(/\s/g, '_');
-                        console.log(`WOKCommands > Command "${names[0]}" has an option of "${name}" with a white space in it. It is a best practice for option names to only be one word. WOKCommands will modify this for you.`);
+                        instance.log(`WOKCommands > Command "${names[0]}" has an option of "${name}" with a white space in it. It is a best practice for option names to only be one word. WOKCommands will modify this for you.`);
                     }
                     options[key].name = lowerCase;
                 }
@@ -244,11 +244,11 @@ class CommandHandler {
             const slashCommands = instance.slashCommands;
             if (testOnly) {
                 for (const id of instance.testServers) {
-                    await slashCommands.create(names[0], description, options, id);
+                    await slashCommands.create(names[0], description, options, instance, id);
                 }
             }
             else {
-                await slashCommands.create(names[0], description, options);
+                await slashCommands.create(names[0], description, options, instance);
             }
         }
         if (callback) {

--- a/dist/FeatureHandler.js
+++ b/dist/FeatureHandler.js
@@ -12,12 +12,12 @@ class FeatureHandler {
     constructor(client, instance, dir, typeScript = false) {
         this._client = client;
         this._instance = instance;
-        this.setup(dir, typeScript);
+        this.setup(dir, typeScript, instance);
     }
-    setup = async (dir, typeScript) => {
+    setup = async (dir, typeScript, instance) => {
         // Register built in features
-        for (const [file, fileName] of get_all_files_1.default(path_1.default.join(__dirname, 'features'), typeScript ? '.ts' : '')) {
-            this.registerFeature(require(file), fileName);
+        for (const [file, fileName] of (0, get_all_files_1.default)(path_1.default.join(__dirname, 'features'), typeScript ? '.ts' : '')) {
+            this.registerFeature(require(file), fileName, instance);
         }
         if (!dir) {
             return;
@@ -25,26 +25,26 @@ class FeatureHandler {
         if (!fs_1.default.existsSync(dir)) {
             throw new Error(`Listeners directory "${dir}" doesn't exist!`);
         }
-        const files = get_all_files_1.default(dir, typeScript ? '.ts' : '');
+        const files = (0, get_all_files_1.default)(dir, typeScript ? '.ts' : '');
         const amount = files.length;
         if (amount > 0) {
-            console.log(`WOKCommands > Loading ${amount} listener${amount === 1 ? '' : 's'}...`);
+            instance.log(`WOKCommands > Loading ${amount} listener${amount === 1 ? '' : 's'}...`);
             for (const [file, fileName] of files) {
                 const debug = `WOKCommands DEBUG > Feature "${fileName}" load time`;
                 if (this._instance.debug) {
                     console.time(debug);
                 }
-                this.registerFeature(require(file), fileName);
+                this.registerFeature(require(file), fileName, instance);
                 if (this._instance.debug) {
                     console.timeEnd(debug);
                 }
             }
         }
         else {
-            console.log(`WOKCommands > Loaded ${amount} listener${amount === 1 ? '' : 's'}.`);
+            instance.log(`WOKCommands > Loaded ${amount} listener${amount === 1 ? '' : 's'}.`);
         }
     };
-    registerFeature = (file, fileName) => {
+    registerFeature = (file, fileName, instance) => {
         let func = file;
         const { config } = file;
         if (file.default) {
@@ -62,11 +62,11 @@ class FeatureHandler {
             if (!dbName)
                 missing.push('dbName');
             if (missing.length && this._instance.showWarns) {
-                console.warn(`WOKCommands > Feature "${fileName}" has a config file that doesn't contain the following properties: ${missing}`);
+                instance.warn(`WOKCommands > Feature "${fileName}" has a config file that doesn't contain the following properties: ${missing}`);
             }
         }
         else if (this._instance.showWarns) {
-            console.warn(`WOKCommands > Feature "${fileName}" does not export a config object.`);
+            instance.warn(`WOKCommands > Feature "${fileName}" does not export a config object.`);
         }
         if (typeof func !== 'function') {
             return;
@@ -78,7 +78,7 @@ class FeatureHandler {
             return this.isEnabled(guildId, file);
         };
         if (config && config.loadDBFirst === true) {
-            console.warn(`WOKCommands > config.loadDBFirst in features is no longer required. MongoDB is now connected to before any features or commands are loaded.`);
+            instance.warn(`WOKCommands > config.loadDBFirst in features is no longer required. MongoDB is now connected to before any features or commands are loaded.`);
         }
         func(this._client, this._instance, isEnabled);
     };

--- a/dist/SlashCommands.js
+++ b/dist/SlashCommands.js
@@ -15,7 +15,7 @@ class SlashCommands {
     }
     async setUp(listen, typeScript = false) {
         // Do not pass in TS here because this should always compiled to JS
-        for (const [file, fileName] of get_all_files_1.default(path_1.default.join(__dirname, 'command-checks'))) {
+        for (const [file, fileName] of (0, get_all_files_1.default)(path_1.default.join(__dirname, 'command-checks'))) {
             this._commandChecks.set(fileName, require(file));
         }
         const replyFromCheck = async (reply, interaction) => {
@@ -71,6 +71,7 @@ class SlashCommands {
                         return;
                     }
                 }
+                // @ts-ignore
                 this.invokeCommand(interaction, commandName, options, args);
             });
         }
@@ -92,12 +93,15 @@ class SlashCommands {
     }
     didOptionsChange(command, options) {
         return (command.options?.filter((opt, index) => {
-            return (opt?.required !== options[index]?.required &&
+            return (
+            // @ts-ignore
+            opt?.required !== options[index]?.required &&
                 opt?.name !== options[index]?.name &&
+                // @ts-ignore
                 opt?.options?.length !== options.length);
         }).length !== 0);
     }
-    async create(name, description, options, guildId) {
+    async create(name, description, options, instance, guildId) {
         let commands;
         if (guildId) {
             commands = this._client.guilds.cache.get(guildId)?.commands;
@@ -116,7 +120,7 @@ class SlashCommands {
             if (cmd.description !== description ||
                 cmd.options.length !== options.length ||
                 optionsChanged) {
-                console.log(`WOKCommands > Updating${guildId ? ' guild' : ''} slash command "${name}"`);
+                instance.log(`WOKCommands > Updating${guildId ? ' guild' : ''} slash command "${name}"`);
                 return commands?.edit(cmd.id, {
                     name,
                     description,
@@ -126,7 +130,7 @@ class SlashCommands {
             return Promise.resolve(cmd);
         }
         if (commands) {
-            console.log(`WOKCommands > Creating${guildId ? ' guild' : ''} slash command "${name}"`);
+            instance.log(`WOKCommands > Creating${guildId ? ' guild' : ''} slash command "${name}"`);
             const newCommand = await commands.create({
                 name,
                 description,
@@ -136,12 +140,12 @@ class SlashCommands {
         }
         return Promise.resolve(undefined);
     }
-    async delete(commandId, guildId) {
+    async delete(commandId, instance, guildId) {
         const commands = this.getCommands(guildId);
         if (commands) {
             const cmd = commands.cache.get(commandId);
             if (cmd) {
-                console.log(`WOKCommands > Deleting${guildId ? ' guild' : ''} slash command "${cmd.name}"`);
+                instance.log(`WOKCommands > Deleting${guildId ? ' guild' : ''} slash command "${cmd.name}"`);
                 cmd.delete();
             }
         }

--- a/dist/commands/help/!ReactionListener.js
+++ b/dist/commands/help/!ReactionListener.js
@@ -89,7 +89,7 @@ class ReactionHandler {
      * Invoked when the user returns to the main menu
      */
     returnToMainMenu = () => {
-        const { embed: newEmbed, reactions } = _get_first_embed_1.default(this.message, this.instance);
+        const { embed: newEmbed, reactions } = (0, _get_first_embed_1.default)(this.message, this.instance);
         this.embed.setDescription(newEmbed.description || '');
         this.message.edit({ embeds: [this.embed] });
         if (this.canBotRemoveReaction()) {
@@ -136,7 +136,7 @@ class ReactionHandler {
     static getHelp = (command, instance, guild) => {
         const { description, syntax, names } = command;
         if (names === undefined) {
-            console.error('WOKCommands > A command does not have a name assigned to it.');
+            instance.error('WOKCommands > A command does not have a name assigned to it.');
             return '';
         }
         const mainName = typeof names === 'string' ? names : names.shift();

--- a/dist/commands/help/!get-first-embed.js
+++ b/dist/commands/help/!get-first-embed.js
@@ -35,7 +35,7 @@ const getFirstEmbed = (message, instance) => {
         const key = keys[a];
         const { emoji } = categories[key];
         if (!emoji) {
-            console.warn(`WOKCommands > Category "${key}" does not have an emoji icon.`);
+            instance.warn(`WOKCommands > Category "${key}" does not have an emoji icon.`);
             continue;
         }
         const visibleCommands = instance.commandHandler.getCommandsByCategory(key, true);

--- a/dist/commands/help/help.js
+++ b/dist/commands/help/help.js
@@ -26,13 +26,13 @@ const discord_js_1 = require("discord.js");
 const _get_first_embed_1 = __importDefault(require("./!get-first-embed"));
 const _ReactionListener_1 = __importStar(require("./!ReactionListener"));
 const sendHelpMenu = (message, instance) => {
-    const { embed, reactions } = _get_first_embed_1.default(message, instance);
+    const { embed, reactions } = (0, _get_first_embed_1.default)(message, instance);
     message.channel
         .send({
         embeds: [embed],
     })
         .then((message) => {
-        _ReactionListener_1.addReactions(message, reactions);
+        (0, _ReactionListener_1.addReactions)(message, reactions);
     });
 };
 module.exports = {
@@ -50,7 +50,7 @@ module.exports = {
         const { message, channel, instance, args } = options;
         const { guild } = channel;
         if (guild && !guild.me?.permissions.has('SEND_MESSAGES')) {
-            console.warn(`WOKCommands > Could not send message due to no permissions in channel for ${guild.name}`);
+            instance.warn(`WOKCommands > Could not send message due to no permissions in channel for ${guild.name}`);
             return;
         }
         if (guild && !guild.me?.permissions.has('ADD_REACTIONS')) {

--- a/dist/commands/slash.js
+++ b/dist/commands/slash.js
@@ -25,7 +25,7 @@ module.exports = {
                 });
             }
             catch (ignored) { }
-            slashCommands.delete(text, useGuild ? guild.id : undefined);
+            slashCommands.delete(text, instance, useGuild ? guild.id : undefined);
             if (useGuild) {
                 return `Slash command with the ID "${text}" has been deleted from guild "${guild.id}".`;
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -54,9 +54,15 @@ class WOKCommands extends events_1.EventEmitter {
     _debug = false;
     _messageHandler = null;
     _slashCommand = null;
+    log;
+    warn;
+    error;
     constructor(client, options) {
         super();
         this._client = client;
+        this.log = options?.logger?.log || console.log;
+        this.warn = options?.logger?.warn || console.warn;
+        this.error = options?.logger?.error || console.error;
         this.setUp(client, options);
     }
     async setUp(client, options) {
@@ -65,8 +71,8 @@ class WOKCommands extends events_1.EventEmitter {
         }
         let { commandsDir = '', commandDir = '', featuresDir = '', featureDir = '', messagesPath, mongoUri, showWarns = true, delErrMsgCooldown = -1, defaultLanguage = 'english', ignoreBots = true, dbOptions, testServers, botOwners, disabledDefaultCommands = [], typeScript = false, ephemeral = true, debug = false, } = options || {};
         if (mongoUri) {
-            await mongo_1.default(mongoUri, this, dbOptions);
-            this._mongoConnection = mongo_1.getMongoConnection();
+            await (0, mongo_1.default)(mongoUri, this, dbOptions);
+            this._mongoConnection = (0, mongo_1.getMongoConnection)();
             const results = await prefixes_1.default.find({});
             for (const result of results) {
                 const { _id, prefix } = result;
@@ -75,7 +81,7 @@ class WOKCommands extends events_1.EventEmitter {
         }
         else {
             if (showWarns) {
-                console.warn('WOKCommands > No MongoDB connection URI provided. Some features might not work! See this for more details:\nhttps://docs.wornoffkeys.com/databases/mongodb');
+                this.warn('WOKCommands > No MongoDB connection URI provided. Some features might not work! See this for more details:\nhttps://docs.wornoffkeys.com/databases/mongodb');
             }
             this.emit(Events_1.default.DATABASE_CONNECTED, null, '');
         }
@@ -124,10 +130,10 @@ class WOKCommands extends events_1.EventEmitter {
             },
         ]);
         this._featureHandler = new FeatureHandler_1.default(client, this, this._featuresDir, typeScript);
-        console.log('WOKCommands > Your bot is now running.');
+        this.log('WOKCommands > Your bot is now running.');
     }
     setMongoPath(mongoPath) {
-        console.warn('WOKCommands > .setMongoPath() no longer works as expected. Please pass in your mongo URI as a "mongoUri" property using the options object. For more information: https://docs.wornoffkeys.com/databases/mongodb');
+        this.warn('WOKCommands > .setMongoPath() no longer works as expected. Please pass in your mongo URI as a "mongoUri" property using the options object. For more information: https://docs.wornoffkeys.com/databases/mongodb');
         return this;
     }
     get client() {
@@ -204,7 +210,7 @@ class WOKCommands extends events_1.EventEmitter {
                 targetEmoji = this._client.emojis.cache.get(emoji);
             }
             if (this.isEmojiUsed(targetEmoji)) {
-                console.warn(`WOKCommands > The emoji "${targetEmoji}" for category "${name}" is already used.`);
+                this.warn(`WOKCommands > The emoji "${targetEmoji}" for category "${name}" is already used.`);
             }
             this._categories.set(name, targetEmoji || this.categories.get(name) || '');
             if (hidden) {
@@ -255,7 +261,7 @@ class WOKCommands extends events_1.EventEmitter {
         return this._botOwner;
     }
     setBotOwner(botOwner) {
-        console.log('WOKCommands > setBotOwner() is deprecated. Please specify your bot owners in the object constructor instead. See https://docs.wornoffkeys.com/setup-and-options-object');
+        this.log('WOKCommands > setBotOwner() is deprecated. Please specify your bot owners in the object constructor instead. See https://docs.wornoffkeys.com/setup-and-options-object');
         if (typeof botOwner === 'string') {
             botOwner = [botOwner];
         }

--- a/dist/message-handler.js
+++ b/dist/message-handler.js
@@ -23,7 +23,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const languages_1 = __importDefault(require("./models/languages"));
-const defualtMessages = require('../messages.json');
+const defaultMessages = require('../messages.json');
 class MessageHandler {
     _instance;
     _guildLanguages = new Map(); // <Guild ID, Language>
@@ -32,7 +32,7 @@ class MessageHandler {
     constructor(instance, messagePath) {
         this._instance = instance;
         (async () => {
-            this._messages = messagePath ? await Promise.resolve().then(() => __importStar(require(messagePath))) : defualtMessages;
+            this._messages = messagePath ? await Promise.resolve().then(() => __importStar(require(messagePath))) : defaultMessages;
             for (const messageId of Object.keys(this._messages)) {
                 for (const language of Object.keys(this._messages[messageId])) {
                     this._languages.push(language.toLowerCase());

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -309,7 +309,7 @@ class Command {
       this._databaseCooldown = true
 
       if (!this.instance.isDBConnected()) {
-        console.warn(
+        this.instance.warn(
           `WOKCommands > A database connection is STRONGLY RECOMMENDED for cooldowns of 5 minutes or more.`
         )
       }

--- a/src/CommandHandler.ts
+++ b/src/CommandHandler.ts
@@ -93,7 +93,7 @@ export default class CommandHandler {
       const files = getAllFiles(dir, typeScript ? '.ts' : '')
       const amount = files.length
 
-      console.log(
+      instance.log(
         `WOKCommands > Loaded ${amount} command${amount === 1 ? '' : 's'}.`
       )
 
@@ -200,7 +200,7 @@ export default class CommandHandler {
             })
           } else {
             message.reply(instance.messageHandler.get(guild, 'EXCEPTION'))
-            console.error(e)
+            instance.error(e)
           }
 
           instance.emit(Events.COMMAND_EXCEPTION, command, message, e)
@@ -305,13 +305,13 @@ export default class CommandHandler {
     }
 
     if (missing.length && instance.showWarns) {
-      console.warn(
+      instance.warn(
         `WOKCommands > Command "${names[0]}" does not have the following properties: ${missing}.`
       )
     }
 
     if (testOnly && !instance.testServers.length) {
-      console.warn(
+      instance.warn(
         `WOKCommands > Command "${names[0]}" has "testOnly" set to true, but no test servers are defined.`
       )
     }
@@ -347,14 +347,14 @@ export default class CommandHandler {
           let lowerCase = name.toLowerCase()
 
           if (name !== lowerCase && instance.showWarns) {
-            console.log(
+            instance.log(
               `WOKCommands > Command "${names[0]}" has an option of "${name}". All option names must be lower case for slash commands. WOKCommands will modify this for you.`
             )
           }
 
           if (lowerCase.match(/\s/g)) {
             lowerCase = lowerCase.replace(/\s/g, '_')
-            console.log(
+            instance.log(
               `WOKCommands > Command "${names[0]}" has an option of "${name}" with a white space in it. It is a best practice for option names to only be one word. WOKCommands will modify this for you.`
             )
           }
@@ -384,10 +384,16 @@ export default class CommandHandler {
       const slashCommands = instance.slashCommands
       if (testOnly) {
         for (const id of instance.testServers) {
-          await slashCommands.create(names[0], description, options, id)
+          await slashCommands.create(
+            names[0],
+            description,
+            options,
+            instance,
+            id
+          )
         }
       } else {
-        await slashCommands.create(names[0], description, options)
+        await slashCommands.create(names[0], description, options, instance)
       }
     }
 

--- a/src/FeatureHandler.ts
+++ b/src/FeatureHandler.ts
@@ -18,16 +18,20 @@ class FeatureHandler {
   ) {
     this._client = client
     this._instance = instance
-    this.setup(dir, typeScript)
+    this.setup(dir, typeScript, instance)
   }
 
-  private setup = async (dir: string, typeScript: boolean) => {
+  private setup = async (
+    dir: string,
+    typeScript: boolean,
+    instance: WOKCommands
+  ) => {
     // Register built in features
     for (const [file, fileName] of getAllFiles(
       path.join(__dirname, 'features'),
       typeScript ? '.ts' : ''
     )) {
-      this.registerFeature(require(file), fileName)
+      this.registerFeature(require(file), fileName, instance)
     }
 
     if (!dir) {
@@ -43,7 +47,7 @@ class FeatureHandler {
     const amount = files.length
 
     if (amount > 0) {
-      console.log(
+      instance.log(
         `WOKCommands > Loading ${amount} listener${amount === 1 ? '' : 's'}...`
       )
 
@@ -53,19 +57,23 @@ class FeatureHandler {
         if (this._instance.debug) {
           console.time(debug)
         }
-        this.registerFeature(require(file), fileName)
+        this.registerFeature(require(file), fileName, instance)
         if (this._instance.debug) {
           console.timeEnd(debug)
         }
       }
     } else {
-      console.log(
+      instance.log(
         `WOKCommands > Loaded ${amount} listener${amount === 1 ? '' : 's'}.`
       )
     }
   }
 
-  private registerFeature = (file: any, fileName: string) => {
+  private registerFeature = (
+    file: any,
+    fileName: string,
+    instance: WOKCommands
+  ) => {
     let func = file
     const { config } = file
 
@@ -85,12 +93,12 @@ class FeatureHandler {
       if (!dbName) missing.push('dbName')
 
       if (missing.length && this._instance.showWarns) {
-        console.warn(
+        instance.warn(
           `WOKCommands > Feature "${fileName}" has a config file that doesn't contain the following properties: ${missing}`
         )
       }
     } else if (this._instance.showWarns) {
-      console.warn(
+      instance.warn(
         `WOKCommands > Feature "${fileName}" does not export a config object.`
       )
     }
@@ -108,7 +116,7 @@ class FeatureHandler {
     }
 
     if (config && config.loadDBFirst === true) {
-      console.warn(
+      instance.warn(
         `WOKCommands > config.loadDBFirst in features is no longer required. MongoDB is now connected to before any features or commands are loaded.`
       )
     }

--- a/src/SlashCommands.ts
+++ b/src/SlashCommands.ts
@@ -116,7 +116,7 @@ class SlashCommands {
             return
           }
         }
-
+        // @ts-ignore
         this.invokeCommand(interaction, commandName, options, args)
       })
     }
@@ -148,8 +148,10 @@ class SlashCommands {
     return (
       command.options?.filter((opt, index) => {
         return (
+          // @ts-ignore
           opt?.required !== options[index]?.required &&
           opt?.name !== options[index]?.name &&
+          // @ts-ignore
           opt?.options?.length !== options.length
         )
       }).length !== 0
@@ -160,6 +162,7 @@ class SlashCommands {
     name: string,
     description: string,
     options: ApplicationCommandOptionData[],
+    instance: WOKCommands,
     guildId?: string
   ): Promise<ApplicationCommand<{}> | undefined> {
     let commands
@@ -189,7 +192,7 @@ class SlashCommands {
         cmd.options.length !== options.length ||
         optionsChanged
       ) {
-        console.log(
+        instance.log(
           `WOKCommands > Updating${
             guildId ? ' guild' : ''
           } slash command "${name}"`
@@ -206,7 +209,7 @@ class SlashCommands {
     }
 
     if (commands) {
-      console.log(
+      instance.log(
         `WOKCommands > Creating${
           guildId ? ' guild' : ''
         } slash command "${name}"`
@@ -226,13 +229,14 @@ class SlashCommands {
 
   public async delete(
     commandId: string,
+    instance: WOKCommands,
     guildId?: string
   ): Promise<ApplicationCommand<{}> | undefined> {
     const commands = this.getCommands(guildId)
     if (commands) {
       const cmd = commands.cache.get(commandId)
       if (cmd) {
-        console.log(
+        instance.log(
           `WOKCommands > Deleting${guildId ? ' guild' : ''} slash command "${
             cmd.name
           }"`

--- a/src/commands/help/!ReactionListener.ts
+++ b/src/commands/help/!ReactionListener.ts
@@ -191,7 +191,7 @@ class ReactionHandler {
   ) => {
     const { description, syntax, names } = command
     if (names === undefined) {
-      console.error(
+      instance.error(
         'WOKCommands > A command does not have a name assigned to it.'
       )
       return ''

--- a/src/commands/help/!get-first-embed.ts
+++ b/src/commands/help/!get-first-embed.ts
@@ -65,7 +65,7 @@ const getFirstEmbed = (
     const { emoji } = categories[key]
 
     if (!emoji) {
-      console.warn(
+      instance.warn(
         `WOKCommands > Category "${key}" does not have an emoji icon.`
       )
 

--- a/src/commands/help/help.ts
+++ b/src/commands/help/help.ts
@@ -36,7 +36,7 @@ module.exports = {
     const { guild } = channel
 
     if (guild && !guild.me?.permissions.has('SEND_MESSAGES')) {
-      console.warn(
+      instance.warn(
         `WOKCommands > Could not send message due to no permissions in channel for ${guild.name}`
       )
       return

--- a/src/commands/slash.ts
+++ b/src/commands/slash.ts
@@ -35,7 +35,7 @@ export = {
         })
       } catch (ignored) {}
 
-      slashCommands.delete(text, useGuild ? guild.id : undefined)
+      slashCommands.delete(text, instance, useGuild ? guild.id : undefined)
 
       if (useGuild) {
         return `Slash command with the ID "${text}" has been deleted from guild "${guild.id}".`

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,11 +35,18 @@ export default class WOKCommands extends EventEmitter {
   private _debug = false
   private _messageHandler: MessageHandler | null = null
   private _slashCommand: SlashCommands | null = null
+  log: CallableFunction
+  warn: CallableFunction
+  error: CallableFunction
 
   constructor(client: Client, options?: Options) {
     super()
 
     this._client = client
+
+    this.log = options?.logger?.log || console.log
+    this.warn = options?.logger?.warn || console.warn
+    this.error = options?.logger?.error || console.error
 
     this.setUp(client, options)
   }
@@ -83,7 +90,7 @@ export default class WOKCommands extends EventEmitter {
       }
     } else {
       if (showWarns) {
-        console.warn(
+        this.warn(
           'WOKCommands > No MongoDB connection URI provided. Some features might not work! See this for more details:\nhttps://docs.wornoffkeys.com/databases/mongodb'
         )
       }
@@ -165,11 +172,11 @@ export default class WOKCommands extends EventEmitter {
       typeScript
     )
 
-    console.log('WOKCommands > Your bot is now running.')
+    this.log('WOKCommands > Your bot is now running.')
   }
 
   public setMongoPath(mongoPath: string | undefined): WOKCommands {
-    console.warn(
+    this.warn(
       'WOKCommands > .setMongoPath() no longer works as expected. Please pass in your mongo URI as a "mongoUri" property using the options object. For more information: https://docs.wornoffkeys.com/databases/mongodb'
     )
     return this
@@ -269,7 +276,7 @@ export default class WOKCommands extends EventEmitter {
       }
 
       if (this.isEmojiUsed(targetEmoji)) {
-        console.warn(
+        this.warn(
           `WOKCommands > The emoji "${targetEmoji}" for category "${name}" is already used.`
         )
       }
@@ -339,7 +346,7 @@ export default class WOKCommands extends EventEmitter {
   }
 
   public setBotOwner(botOwner: string | string[]): WOKCommands {
-    console.log(
+    this.log(
       'WOKCommands > setBotOwner() is deprecated. Please specify your bot owners in the object constructor instead. See https://docs.wornoffkeys.com/setup-and-options-object'
     )
 

--- a/src/message-handler.ts
+++ b/src/message-handler.ts
@@ -3,7 +3,7 @@ import { Guild } from 'discord.js'
 import languageSchema from './models/languages'
 import WOKCommands from '.'
 import Events from './enums/Events'
-const defualtMessages = require('../messages.json')
+const defaultMessages = require('../messages.json')
 
 export default class MessageHandler {
   private _instance: WOKCommands
@@ -18,7 +18,7 @@ export default class MessageHandler {
   constructor(instance: WOKCommands, messagePath: string) {
     this._instance = instance
     ;(async () => {
-      this._messages = messagePath ? await import(messagePath) : defualtMessages
+      this._messages = messagePath ? await import(messagePath) : defaultMessages
 
       for (const messageId of Object.keys(this._messages)) {
         for (const language of Object.keys(this._messages[messageId])) {

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -96,6 +96,7 @@ interface OptionsWithS {
   typeScript?: boolean
   ephemeral?: boolean
   debug?: boolean
+  logger?: { log: function; warn: function; error: function }
 }
 
 interface OptionsWithoutS {
@@ -117,6 +118,11 @@ interface OptionsWithoutS {
   typeScript?: boolean
   ephemeral?: boolean
   debug?: boolean
+  logger?: {
+    log: CallableFunction
+    warn: CallableFunction
+    error: CallableFunction
+  }
 }
 export type Options = OptionsWithS | OptionsWithoutS
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -96,7 +96,11 @@ interface OptionsWithS {
   typeScript?: boolean
   ephemeral?: boolean
   debug?: boolean
-  logger?: { log: function; warn: function; error: function }
+  logger?: {
+    log: CallableFunction
+    warn: CallableFunction
+    error: CallableFunction
+  }
 }
 
 interface OptionsWithoutS {


### PR DESCRIPTION
Add `logger` to constructor options, so instead of using console.log you can pass in a function that handles logging
``` javascript
new WOKcommands(client, {
    ...
    logger: {
      log: (a) => log.info(a),
      warn: (a) => log.warn(a),
      error: (a) => log.error(a)
    }
  });
```
If nothing is supplied, standard console logging is used, so **no breaking change**.