### PR TITLE
Add voiceOnly parameter to command properties

### DIFF
--- a/dist/Command.js
+++ b/dist/Command.js
@@ -25,6 +25,7 @@ class Command {
     _globalCooldown;
     _guildCooldowns = new Map(); // <GuildID, Seconds>
     _databaseCooldown = false;
+    _voiceOnly = false;
     _ownerOnly = false;
     _hidden = false;
     _guildOnly = false;
@@ -32,7 +33,7 @@ class Command {
     _slash = false;
     _requireRoles = false;
     _requiredChannels = new Map(); // <GuildID-Command, Channel IDs>
-    constructor(instance, client, names, callback, error, { category, minArgs, maxArgs, syntaxError, expectedArgs, description, requiredPermissions, permissions, cooldown, globalCooldown, ownerOnly = false, hidden = false, guildOnly = false, testOnly = false, slash = false, requireRoles = false, }) {
+    constructor(instance, client, names, callback, error, { category, minArgs, maxArgs, syntaxError, expectedArgs, description, requiredPermissions, permissions, cooldown, globalCooldown, voiceOnly = false, ownerOnly = false, hidden = false, guildOnly = false, testOnly = false, slash = false, requireRoles = false, }) {
         this.instance = instance;
         this.client = client;
         this._names = typeof names === 'string' ? [names] : names;
@@ -45,6 +46,7 @@ class Command {
         this._requiredPermissions = requiredPermissions || permissions;
         this._cooldown = cooldown || '';
         this._globalCooldown = globalCooldown || '';
+        this._voiceOnly = voiceOnly;
         this._ownerOnly = ownerOnly;
         this._hidden = hidden;
         this._guildOnly = guildOnly;
@@ -203,6 +205,9 @@ class Command {
     }
     get ownerOnly() {
         return this._ownerOnly;
+    }
+    get voiceOnly() {
+        return this._voiceOnly;
     }
     verifyDatabaseCooldowns() {
         if (this._cooldownChar === 'd' ||

--- a/dist/command-checks/voice-channel-checks.js
+++ b/dist/command-checks/voice-channel-checks.js
@@ -1,0 +1,24 @@
+"use strict";
+const Discord = require('discord.js')
+
+module.exports = (guild, command, instance, member, user, reply) => {
+    const { voiceOnly } = command;
+    if (!voiceOnly) {
+        return true;
+    }
+    if (!(member instanceof Discord.GuildMember) || !member.voice.channel) {
+        reply(instance.messageHandler.get(guild, 'VOICE_CHANNEL_ONLY')).then((message) => {
+            if (!message) {
+                return;
+            }
+            if (instance.delErrMsgCooldown === -1 || !message.deletable) {
+                return;
+            }
+            setTimeout(() => {
+                message.delete();
+            }, 1000 * instance.delErrMsgCooldown);
+        });
+        return false;
+    }
+    return true;
+};

--- a/messages.json
+++ b/messages.json
@@ -26,6 +26,15 @@
     "dutch": "Taal ingesteld op {LANGUAGE}.",
     "french": "Langue réglée sur {LANGUAGE}."
   },
+  "VOICE_CHANNEL_ONLY": {
+    "english": "You should be in a voice channel in order to use this command",
+    "spanish": "Debe estar en un canal de voz para usar este comando",
+    "portuguese": "Você deve estar em um canal de voz para usar este comando",
+    "russian": "Вы должны быть в голосовом канале, чтобы использовать эту команду",
+    "german": "Sie müssen sich in einem Sprachkanal befinden, um diesen Befehl verwenden zu können",
+    "dutch": "Je moet in een spraakkanaal zijn om deze opdracht te gebruiken",
+    "french": "Vous devez être dans un canal vocal pour utiliser cette commande"
+  },
   "BOT_OWNERS_ONLY": {
     "english": "Only the bot owner can run this command.",
     "spanish": "Solo el propietario del bot puede ejecutar este comando.",

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -27,6 +27,7 @@ class Command {
   private _globalCooldown: string
   private _guildCooldowns: Map<String, number> = new Map() // <GuildID, Seconds>
   private _databaseCooldown = false
+  private _voiceOnly = false
   private _ownerOnly = false
   private _hidden = false
   private _guildOnly = false
@@ -52,6 +53,7 @@ class Command {
       permissions,
       cooldown,
       globalCooldown,
+      voiceOnly = false,
       ownerOnly = false,
       hidden = false,
       guildOnly = false,
@@ -72,6 +74,7 @@ class Command {
     this._requiredPermissions = requiredPermissions || permissions
     this._cooldown = cooldown || ''
     this._globalCooldown = globalCooldown || ''
+    this._voiceOnly = voiceOnly
     this._ownerOnly = ownerOnly
     this._hidden = hidden
     this._guildOnly = guildOnly
@@ -298,6 +301,10 @@ class Command {
 
   public get ownerOnly(): boolean {
     return this._ownerOnly
+  }
+
+  public get voiceOnly(): boolean {
+    return this._voiceOnly
   }
 
   public verifyDatabaseCooldowns() {

--- a/src/command-checks/voice-channel-checks.ts
+++ b/src/command-checks/voice-channel-checks.ts
@@ -1,0 +1,40 @@
+import { Guild, GuildMember, Message, User } from 'discord.js'
+import WOKCommands from '..'
+import Command from '../Command'
+
+export = (
+  guild: Guild | null,
+  command: Command,
+  instance: WOKCommands,
+  member: GuildMember,
+  user: User,
+  reply: Function
+) => {
+  const { voiceOnly } = command
+
+  if (!voiceOnly) {
+    return true
+  }
+
+  if (!(member instanceof GuildMember) || !member.voice.channel) {
+    reply(instance.messageHandler.get(guild, 'VOICE_CHANNEL_ONLY')).then(
+      (message: Message | null) => {
+        if (!message) {
+          return
+        }
+
+        if (instance.delErrMsgCooldown === -1 || !message.deletable) {
+          return
+        }
+
+        setTimeout(() => {
+          message.delete()
+        }, 1000 * instance.delErrMsgCooldown)
+      }
+    )
+
+    return false
+  }
+
+  return true
+}

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -172,6 +172,7 @@ export interface ICommand {
   permissions?: PermissionString[]
   cooldown?: string
   globalCooldown?: string
+  voiceOnly?: boolean
   ownerOnly?: boolean
   hidden?: boolean
   guildOnly?: boolean


### PR DESCRIPTION
This option allows the user to decide whether the command can be executed without being present in the voice channel. If set to true, command can't be executed while user is not in the voice channel. Else if false, it just does nothing. Example:
```ts
export default {
   voiceOnly: true
} as ICommand